### PR TITLE
Handle Edge as an IE browser.

### DIFF
--- a/src/browser-detector.js
+++ b/src/browser-detector.js
@@ -5,7 +5,7 @@ var detector = module.exports = {};
 detector.isIE = function(version) {
     function isAnyIeVersion() {
         var agent = navigator.userAgent.toLowerCase();
-        return agent.indexOf("msie") !== -1 || agent.indexOf("trident") !== -1;
+        return agent.indexOf("msie") !== -1 || agent.indexOf("trident") !== -1 || agent.indexOf(" edge/") !== -1;
     }
 
     if(!isAnyIeVersion()) {


### PR DESCRIPTION
Edge was handled as a non IE browser, and no resize events was triggered. But when handling Edge as an IE browser, events are triggered again.