### PR TITLE
don't try to remove listeners if element isn't registered

### DIFF
--- a/src/listener-handler.js
+++ b/src/listener-handler.js
@@ -40,7 +40,9 @@ module.exports = function(idHandler) {
     }
 
     function removeAllListeners(element) {
-      eventListeners[idHandler.get(element)].length = 0;
+      var listeners = eventListeners[idHandler.get(element)];
+      if (!listeners) { return; }
+      listeners.length = 0;
     }
 
     return {


### PR DESCRIPTION
I've run into a situation where `listenTo` may or may not have been called on an element before, but I need to be sure there are no listeners. Is there any problem with letting `removeAllListeners` succeed on an uninstalled element?