### PR TITLE
use window.getComputedStyle

### DIFF
--- a/src/detection-strategy/object.js
+++ b/src/detection-strategy/object.js
@@ -71,7 +71,7 @@ module.exports = function(options) {
 
             // The element may not yet be attached to the DOM, and therefore the style object may be empty in some browsers.
             // Since the style object is a reference, it will be updated as soon as the element is attached to the DOM.
-            var style = getComputedStyle(element);
+            var style = window.getComputedStyle(element);
             var width = element.offsetWidth;
             var height = element.offsetHeight;
 


### PR DESCRIPTION
Thanks for this useful lib!

Because the `global` in NodeJS is not `window`, it would be better if we use  `window.getComputedStyle` instead of using `getComputedStyle` directly.

I ran into this issue when I ran my tests in `jsdom`. Currently, I use `gobal.getComputedStyle  = window.getComputedStyle` before my tests to fix it.