### PR TITLE
Display block for erd_scroll_detection_container (IE bug fix)

### DIFF
--- a/src/detection-strategy/scroll.js
+++ b/src/detection-strategy/scroll.js
@@ -257,7 +257,7 @@ module.exports = function(options) {
                 container                   = document.createElement("div");
                 container.dir               = "ltr"; // Some browsers choke on the resize system being rtl, so force it to ltr. #https://github.com/wnr/element-resize-detector/issues/56
                 container.className         = detectionContainerClass;
-                container.style.cssText     = "visibility: hidden; display: inline; width: 0px; height: 0px; z-index: -1; overflow: hidden; margin: 0; padding: 0;";
+                container.style.cssText     = "visibility: hidden; display: block; width: 0px; height: 0px; z-index: -1; overflow: hidden; margin: 0; padding: 0;";
                 getState(element).container = container;
                 addAnimationClass(container);
                 element.appendChild(container);


### PR DESCRIPTION
Hi... inline styles `display: inline; width: 0px; height: 0px` don't make much sense to me. Inline elements don't have width or height. In IE10 it renders as space (an empty line). Is there any reason for this? 

In my project I am using css
```
.erd_scroll_detection_container {
    display: block !important;
}
```
..this fixed the issue (mo more empty lines in IE) and looks like measurements are working just fine (using this module as a dependency of react-measure -> react-motion-ui-pack)