### PR TITLE
Handle case where container is undefined in isUnrendered

### DIFF
--- a/src/detection-strategy/scroll.js
+++ b/src/detection-strategy/scroll.js
@@ -170,7 +170,7 @@ module.exports = function(options) {
         function isUnrendered(element) {
             // Check the absolute positioned container since the top level container is display: inline.
             var container = getState(element).container.childNodes[0];
-            return getComputedStyle(container).width.indexOf("px") === -1; //Can only compute pixel value when rendered.
+            return !container || getComputedStyle(container).width.indexOf("px") === -1; //Can only compute pixel value when rendered.
         }
 
         function getStyle() {


### PR DESCRIPTION
If `container` is undefined then getComputedStyle will throw an Error.