### PR TITLE
Fixes #61: Protect from elements not being injected

### DIFF
--- a/src/detection-strategy/scroll.js
+++ b/src/detection-strategy/scroll.js
@@ -427,6 +427,11 @@ module.exports = function(options) {
                         return;
                     }
 
+                    if (!areElementsInjected()) {
+                        debug("Aborting because element container has not been initialized");
+                        return;
+                    }
+
                     if (options.debug) {
                         var w = element.offsetWidth;
                         var h = element.offsetHeight;
@@ -445,6 +450,11 @@ module.exports = function(options) {
                         return;
                     }
 
+                    if (!areElementsInjected()) {
+                        debug("Aborting because element container has not been initialized");
+                        return;
+                    }
+
                     positionScrollbars(element, width, height);
                 });
 
@@ -453,6 +463,11 @@ module.exports = function(options) {
                         if (!getState(element)) {
                             debug("Aborting because element has been uninstalled");
                             return;
+                        }
+
+                        if (!areElementsInjected()) {
+                          debug("Aborting because element container has not been initialized");
+                          return;
                         }
 
                         done();


### PR DESCRIPTION
Hello,

We've had the same issue described in #61. We're also using element-resize-detector with React and can end up reusing the same element between uninstall/install.

I've just added guards to ensure that container element is injected.