### PR TITLE
[PATCH] Adding ada compatibility

### DIFF
--- a/src/detection-strategy/object.js
+++ b/src/detection-strategy/object.js
@@ -153,6 +153,7 @@ module.exports = function(options) {
                 object.style.cssText = OBJECT_STYLE;
                 object.tabIndex = -1;
                 object.type = "text/html";
+                object.setAttribute("aria-hidden", "true");
                 object.onload = onObjectLoad;
 
                 //Safari: This must occur before adding the object to the DOM.


### PR DESCRIPTION
### Summary
- When the object tag is encapsulating a bunch of divs, right swiping after the last element is selected was causing `object` to be declared by google talk back.

### Test summary
![screen shot 2019-01-30 at 9 57 40 am](https://user-images.githubusercontent.com/9494357/52002146-09c29a00-2476-11e9-8ec4-0bfe7de2edad.png)
