### PR TITLE
Memoize scrollbar width

### DIFF
--- a/src/detection-strategy/scroll.js
+++ b/src/detection-strategy/scroll.js
@@ -7,6 +7,8 @@
 
 var forEach = require("../collection-utils").forEach;
 
+var scrollbarSizes;
+
 module.exports = function(options) {
     options             = options || {};
     var reporter        = options.reporter;
@@ -23,8 +25,9 @@ module.exports = function(options) {
         throw new Error("Missing required dependency: reporter.");
     }
 
-    //TODO: Could this perhaps be done at installation time?
-    var scrollbarSizes = getScrollbarSizes();
+    if (!scrollbarSizes) {
+        scrollbarSizes = getScrollbarSizes();
+    }
 
     var styleId = "erd_scroll_detection_scrollbar_style";
     var detectionContainerClass = "erd_scroll_detection_container";


### PR DESCRIPTION
Store and reuse scrollbar width used in the scroll detection strategy,
as generated by the `getScrollbarSizes` function, instead of
generating it on every use of element-resize-detector.

For context, when profiling I noticed this change improves page load
speed by ~3-10ms for every use.