### PR TITLE
Modernize the code 

### DIFF
--- a/src/browser-detector.js
+++ b/src/browser-detector.js
@@ -1,10 +1,10 @@
 "use strict";
 
-var detector = module.exports = {};
+const detector = module.exports = {};
 
 detector.isIE = function(version) {
     function isAnyIeVersion() {
-        var agent = navigator.userAgent.toLowerCase();
+        const agent = navigator.userAgent.toLowerCase();
         return agent.indexOf("msie") !== -1 || agent.indexOf("trident") !== -1 || agent.indexOf(" edge/") !== -1;
     }
 
@@ -17,11 +17,8 @@ detector.isIE = function(version) {
     }
 
     //Shamelessly stolen from https://gist.github.com/padolsey/527683
-    var ieVersion = (function(){
-        var undef,
-            v = 3,
-            div = document.createElement("div"),
-            all = div.getElementsByTagName("i");
+    const ieVersion = (function(){
+        let undef, v = 3, div = document.createElement("div"), all = div.getElementsByTagName("i");
 
         do {
             div.innerHTML = "<!--[if gt IE " + (++v) + "]><i></i><![endif]-->";

--- a/src/browser-detector.js
+++ b/src/browser-detector.js
@@ -21,7 +21,7 @@ detector.isIE = function(version) {
         let undef, v = 3, div = document.createElement("div"), all = div.getElementsByTagName("i");
 
         do {
-            div.innerHTML = "<!--[if gt IE " + (++v) + "]><i></i><![endif]-->";
+            div.innerHTML = `<!--[if gt IE ${++v}]><i></i><![endif]-->`;
         }
         while (all[0]);
 

--- a/src/collection-utils.js
+++ b/src/collection-utils.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var utils = module.exports = {};
+const utils = module.exports = {};
 
 /**
  * Loops through the collection and calls the callback for each element. if the callback returns truthy, the loop is broken and returns the same value.
@@ -10,8 +10,8 @@ var utils = module.exports = {};
  * @returns {*} The value that a callback has returned (if truthy). Otherwise nothing.
  */
 utils.forEach = function(collection, callback) {
-    for(var i = 0; i < collection.length; i++) {
-        var result = callback(collection[i]);
+    for(let i = 0; i < collection.length; i++) {
+        const result = callback(collection[i]);
         if(result) {
             return result;
         }

--- a/src/detection-strategy/object.js
+++ b/src/detection-strategy/object.js
@@ -100,7 +100,7 @@ module.exports = function(options) {
                             var value = style[property];
 
                             if(value !== "auto" && getNumericalValue(value) !== "0") {
-                                reporter.warn("An element that is positioned static has style." + property + "=" + value + " which is ignored due to the static positioning. The element will need to be positioned relative, so the style." + property + " will be set to 0. Element: ", element);
+                                reporter.warn(`An element that is positioned static has style.${property}=${value} which is ignored due to the static positioning. The element will need to be positioned relative, so the style.${property} will be set to 0. Element: `, element);
                                 element.style.setProperty(property, "0", options.important ? "important" : "");
                             }
                         };

--- a/src/detection-strategy/object.js
+++ b/src/detection-strategy/object.js
@@ -83,8 +83,8 @@ module.exports = function(options) {
             const height = element.offsetHeight;
 
             getState(element).startSize = {
-                width: width,
-                height: height
+                width,
+                height
             };
 
             function mutateDom() {
@@ -240,8 +240,8 @@ module.exports = function(options) {
     }
 
     return {
-        makeDetectable: makeDetectable,
-        addListener: addListener,
-        uninstall: uninstall
+        makeDetectable,
+        addListener,
+        uninstall
     };
 };

--- a/src/detection-strategy/object.js
+++ b/src/detection-strategy/object.js
@@ -5,13 +5,13 @@
 
 "use strict";
 
-var browserDetector = require("../browser-detector");
+const browserDetector = require("../browser-detector");
 
 module.exports = function(options) {
     options             = options || {};
-    var reporter        = options.reporter;
-    var batchProcessor  = options.batchProcessor;
-    var getState        = options.stateHandler.getState;
+    const reporter        = options.reporter;
+    const batchProcessor  = options.batchProcessor;
+    const getState        = options.stateHandler.getState;
 
     if(!reporter) {
         throw new Error("Missing required dependency: reporter.");
@@ -46,7 +46,7 @@ module.exports = function(options) {
     }
 
     function buildCssTextString(rules) {
-        var seperator = options.important ? " !important; " : "; ";
+        const seperator = options.important ? " !important; " : "; ";
 
         return (rules.join(seperator) + seperator).trim();
     }
@@ -66,21 +66,21 @@ module.exports = function(options) {
         }
 
         options = options || {};
-        var debug = options.debug;
+        const debug = options.debug;
 
         function injectObject(element, callback) {
-            var OBJECT_STYLE = buildCssTextString(["display: block", "position: absolute", "top: 0", "left: 0", "width: 100%", "height: 100%", "border: none", "padding: 0", "margin: 0", "opacity: 0", "z-index: -1000", "pointer-events: none", "visibility: hidden"]);
+            const OBJECT_STYLE = buildCssTextString(["display: block", "position: absolute", "top: 0", "left: 0", "width: 100%", "height: 100%", "border: none", "padding: 0", "margin: 0", "opacity: 0", "z-index: -1000", "pointer-events: none", "visibility: hidden"]);
 
             //The target element needs to be positioned (everything except static) so the absolute positioned object will be positioned relative to the target element.
 
             // Position altering may be performed directly or on object load, depending on if style resolution is possible directly or not.
-            var positionCheckPerformed = false;
+            let positionCheckPerformed = false;
 
             // The element may not yet be attached to the DOM, and therefore the style object may be empty in some browsers.
             // Since the style object is a reference, it will be updated as soon as the element is attached to the DOM.
-            var style = window.getComputedStyle(element);
-            var width = element.offsetWidth;
-            var height = element.offsetHeight;
+            const style = window.getComputedStyle(element);
+            const width = element.offsetWidth;
+            const height = element.offsetHeight;
 
             getState(element).startSize = {
                 width: width,
@@ -92,7 +92,7 @@ module.exports = function(options) {
                     if(style.position === "static") {
                         element.style.setProperty("position", "relative", options.important ? "important" : "");
 
-                        var removeRelativeStyles = function(reporter, element, style, property) {
+                        const removeRelativeStyles = function(reporter, element, style, property) {
                             function getNumericalValue(value) {
                                 return value.replace(/[^-\d\.]/g, "");
                             }
@@ -127,7 +127,7 @@ module.exports = function(options) {
                         //So if it is not present, poll it with an timeout until it is present.
                         //TODO: Could maybe be handled better with object.onreadystatechange or similar.
                         if(!element.contentDocument) {
-                            var state = getState(element);
+                            const state = getState(element);
                             if (state.checkForObjectDocumentTimeoutId) {
                                 window.clearTimeout(state.checkForObjectDocumentTimeoutId);
                             }
@@ -144,7 +144,7 @@ module.exports = function(options) {
 
                     //Mutating the object element here seems to fire another load event.
                     //Mutating the inner document of the object element is fine though.
-                    var objectElement = this;
+                    const objectElement = this;
 
                     //Create the style element to be added to the object.
                     getDocument(objectElement, function onObjectDocumentReady(objectDocument) {
@@ -161,7 +161,7 @@ module.exports = function(options) {
                 }
 
                 //Add an object element as a child to the target element that will be listened to for resize events.
-                var object = document.createElement("object");
+                const object = document.createElement("object");
                 object.style.cssText = OBJECT_STYLE;
                 object.tabIndex = -1;
                 object.type = "text/html";
@@ -220,7 +220,7 @@ module.exports = function(options) {
             return;
         }
 
-        var object = getObject(element);
+        const object = getObject(element);
 
         if (!object) {
             return;

--- a/src/detection-strategy/scroll.js
+++ b/src/detection-strategy/scroll.js
@@ -654,9 +654,9 @@ module.exports = function(options) {
     }
 
     return {
-        makeDetectable: makeDetectable,
-        addListener: addListener,
-        uninstall: uninstall,
-        initDocument: initDocument
+        makeDetectable,
+        addListener,
+        uninstall,
+        initDocument
     };
 };

--- a/src/detection-strategy/scroll.js
+++ b/src/detection-strategy/scroll.js
@@ -5,15 +5,15 @@
 
 "use strict";
 
-var forEach = require("../collection-utils").forEach;
+const forEach = require("../collection-utils").forEach;
 
 module.exports = function(options) {
     options             = options || {};
-    var reporter        = options.reporter;
-    var batchProcessor  = options.batchProcessor;
-    var getState        = options.stateHandler.getState;
-    var hasState        = options.stateHandler.hasState;
-    var idHandler       = options.idHandler;
+    const reporter        = options.reporter;
+    const batchProcessor  = options.batchProcessor;
+    const getState        = options.stateHandler.getState;
+    const hasState        = options.stateHandler.hasState;
+    const idHandler       = options.idHandler;
 
     if (!batchProcessor) {
         throw new Error("Missing required dependency: batchProcessor");
@@ -24,10 +24,10 @@ module.exports = function(options) {
     }
 
     //TODO: Could this perhaps be done at installation time?
-    var scrollbarSizes = getScrollbarSizes();
+    const scrollbarSizes = getScrollbarSizes();
 
-    var styleId = "erd_scroll_detection_scrollbar_style";
-    var detectionContainerClass = "erd_scroll_detection_container";
+    const styleId = "erd_scroll_detection_scrollbar_style";
+    const detectionContainerClass = "erd_scroll_detection_container";
 
     function initDocument(targetDocument) {
         // Inject the scrollbar styling that prevents them from appearing sometimes in Chrome.
@@ -38,27 +38,27 @@ module.exports = function(options) {
     initDocument(window.document);
 
     function buildCssTextString(rules) {
-        var seperator = options.important ? " !important; " : "; ";
+        const seperator = options.important ? " !important; " : "; ";
 
         return (rules.join(seperator) + seperator).trim();
     }
 
     function getScrollbarSizes() {
-        var width = 500;
-        var height = 500;
+        const width = 500;
+        const height = 500;
 
-        var child = document.createElement("div");
+        const child = document.createElement("div");
         child.style.cssText = buildCssTextString(["position: absolute", "width: " + width*2 + "px", "height: " + height*2 + "px", "visibility: hidden", "margin: 0", "padding: 0"]);
 
-        var container = document.createElement("div");
+        const container = document.createElement("div");
         container.style.cssText = buildCssTextString(["position: absolute", "width: " + width + "px", "height: " + height + "px", "overflow: scroll", "visibility: none", "top: " + -width*3 + "px", "left: " + -height*3 + "px", "visibility: hidden", "margin: 0", "padding: 0"]);
 
         container.appendChild(child);
 
         document.body.insertBefore(container, document.body.firstChild);
 
-        var widthSize = width - container.clientWidth;
-        var heightSize = height - container.clientHeight;
+        const widthSize = width - container.clientWidth;
+        const heightSize = height - container.clientHeight;
 
         document.body.removeChild(container);
 
@@ -74,7 +74,7 @@ module.exports = function(options) {
                 targetDocument.head.appendChild(element);
             };
 
-            var styleElement = targetDocument.createElement("style");
+            const styleElement = targetDocument.createElement("style");
             styleElement.innerHTML = style;
             styleElement.id = styleId;
             method(styleElement);
@@ -82,8 +82,8 @@ module.exports = function(options) {
         }
 
         if (!targetDocument.getElementById(styleId)) {
-            var containerAnimationClass = containerClass + "_animation";
-            var containerAnimationActiveClass = containerClass + "_animation_active";
+            const containerAnimationClass = containerClass + "_animation";
+            const containerAnimationActiveClass = containerClass + "_animation_active";
             var style = "/* Created by the element-resize-detector library. */\n";
             style += "." + containerClass + " > div::-webkit-scrollbar { " + buildCssTextString(["display: none"]) + " }\n\n";
             style += "." + containerAnimationActiveClass + " { " + buildCssTextString(["-webkit-animation-duration: 0.1s", "animation-duration: 0.1s", "-webkit-animation-name: " + containerAnimationClass, "animation-name: " + containerAnimationClass]) + " }\n";
@@ -132,7 +132,7 @@ module.exports = function(options) {
      * @param {function} listener The listener callback to be called for each resize event of the element. The element will be given as a parameter to the listener callback.
      */
     function addListener(element, listener) {
-        var listeners = getState(element).listeners;
+        const listeners = getState(element).listeners;
 
         if (!listeners.push) {
             throw new Error("Cannot add listener to an element that is not detectable.");
@@ -159,12 +159,12 @@ module.exports = function(options) {
 
         function debug() {
             if (options.debug) {
-                var args = Array.prototype.slice.call(arguments);
+                const args = Array.prototype.slice.call(arguments);
                 args.unshift(idHandler.get(element), "Scroll: ");
                 if (reporter.log.apply) {
                     reporter.log.apply(null, args);
                 } else {
-                    for (var i = 0; i < args.length; i++) {
+                    for (let i = 0; i < args.length; i++) {
                         reporter.log(args[i]);
                     }
                 }
@@ -173,7 +173,7 @@ module.exports = function(options) {
 
         function isDetached(element) {
             function isInDocument(element) {
-                var isInShadowRoot = element.getRootNode && element.getRootNode().contains(element);
+                const isInShadowRoot = element.getRootNode && element.getRootNode().contains(element);
                 return element === element.ownerDocument.body || element.ownerDocument.body.contains(element) || isInShadowRoot;
             }
 
@@ -191,16 +191,16 @@ module.exports = function(options) {
 
         function isUnrendered(element) {
             // Check the absolute positioned container since the top level container is display: inline.
-            var container = getState(element).container.childNodes[0];
-            var style = window.getComputedStyle(container);
+            const container = getState(element).container.childNodes[0];
+            const style = window.getComputedStyle(container);
             return !style.width || style.width.indexOf("px") === -1; //Can only compute pixel value when rendered.
         }
 
         function getStyle() {
             // Some browsers only force layouts when actually reading the style properties of the style object, so make sure that they are all read here,
             // so that the user of the function can be sure that it will perform the layout here, instead of later (important for batching).
-            var elementStyle            = window.getComputedStyle(element);
-            var style                   = {};
+            const elementStyle            = window.getComputedStyle(element);
+            const style                   = {};
             style.position              = elementStyle.position;
             style.width                 = element.offsetWidth;
             style.height                = element.offsetHeight;
@@ -214,7 +214,7 @@ module.exports = function(options) {
         }
 
         function storeStartSize() {
-            var style = getStyle();
+            const style = getStyle();
             getState(element).startSize = {
                 width: style.width,
                 height: style.height
@@ -233,7 +233,7 @@ module.exports = function(options) {
                 return;
             }
 
-            var style = getStyle();
+            const style = getStyle();
             getState(element).style = style;
         }
 
@@ -271,12 +271,12 @@ module.exports = function(options) {
         }
 
         function positionScrollbars(element, width, height) {
-            var expand          = getExpandElement(element);
-            var shrink          = getShrinkElement(element);
-            var expandWidth     = getExpandWidth(width);
-            var expandHeight    = getExpandHeight(height);
-            var shrinkWidth     = getShrinkWidth(width);
-            var shrinkHeight    = getShrinkHeight(height);
+            const expand          = getExpandElement(element);
+            const shrink          = getShrinkElement(element);
+            const expandWidth     = getExpandWidth(width);
+            const expandHeight    = getExpandHeight(height);
+            const shrinkWidth     = getShrinkWidth(width);
+            const shrinkHeight    = getShrinkHeight(height);
             expand.scrollLeft   = expandWidth;
             expand.scrollTop    = expandHeight;
             shrink.scrollLeft   = shrinkWidth;
@@ -284,7 +284,7 @@ module.exports = function(options) {
         }
 
         function injectContainerElement() {
-            var container = getState(element).container;
+            let container = getState(element).container;
 
             if (!container) {
                 container                   = document.createElement("div");
@@ -294,7 +294,7 @@ module.exports = function(options) {
                 addAnimationClass(container);
                 element.appendChild(container);
 
-                var onAnimationStart = function () {
+                const onAnimationStart = function () {
                     getState(element).onRendered && getState(element).onRendered();
                 };
 
@@ -310,12 +310,12 @@ module.exports = function(options) {
 
         function injectScrollElements() {
             function alterPositionStyles() {
-                var style = getState(element).style;
+                const style = getState(element).style;
 
                 if(style.position === "static") {
                     element.style.setProperty("position", "relative",options.important ? "important" : "");
 
-                    var removeRelativeStyles = function(reporter, element, style, property) {
+                    const removeRelativeStyles = function(reporter, element, style, property) {
                         function getNumericalValue(value) {
                             return value.replace(/[^-\d\.]/g, "");
                         }
@@ -355,7 +355,7 @@ module.exports = function(options) {
 
             alterPositionStyles();
 
-            var rootContainer = getState(element).container;
+            let rootContainer = getState(element).container;
 
             if (!rootContainer) {
                 rootContainer = injectContainerElement();
@@ -369,21 +369,21 @@ module.exports = function(options) {
             // The outer container can occasionally be less wide than the targeted when inside inline elements element in WebKit (see https://bugs.webkit.org/show_bug.cgi?id=152980).
             // This should be no problem since the inner container either way makes sure the injected scroll elements are at least 1x1 px.
 
-            var scrollbarWidth          = scrollbarSizes.width;
-            var scrollbarHeight         = scrollbarSizes.height;
-            var containerContainerStyle = buildCssTextString(["position: absolute", "flex: none", "overflow: hidden", "z-index: -1", "visibility: hidden", "width: 100%", "height: 100%", "left: 0px", "top: 0px"]);
-            var containerStyle          = buildCssTextString(["position: absolute", "flex: none", "overflow: hidden", "z-index: -1", "visibility: hidden"].concat(getLeftTopBottomRightCssText(-(1 + scrollbarWidth), -(1 + scrollbarHeight), -scrollbarHeight, -scrollbarWidth)));
-            var expandStyle             = buildCssTextString(["position: absolute", "flex: none", "overflow: scroll", "z-index: -1", "visibility: hidden", "width: 100%", "height: 100%"]);
-            var shrinkStyle             = buildCssTextString(["position: absolute", "flex: none", "overflow: scroll", "z-index: -1", "visibility: hidden", "width: 100%", "height: 100%"]);
-            var expandChildStyle        = buildCssTextString(["position: absolute", "left: 0", "top: 0"]);
-            var shrinkChildStyle        = buildCssTextString(["position: absolute", "width: 200%", "height: 200%"]);
+            const scrollbarWidth          = scrollbarSizes.width;
+            const scrollbarHeight         = scrollbarSizes.height;
+            const containerContainerStyle = buildCssTextString(["position: absolute", "flex: none", "overflow: hidden", "z-index: -1", "visibility: hidden", "width: 100%", "height: 100%", "left: 0px", "top: 0px"]);
+            const containerStyle          = buildCssTextString(["position: absolute", "flex: none", "overflow: hidden", "z-index: -1", "visibility: hidden"].concat(getLeftTopBottomRightCssText(-(1 + scrollbarWidth), -(1 + scrollbarHeight), -scrollbarHeight, -scrollbarWidth)));
+            const expandStyle             = buildCssTextString(["position: absolute", "flex: none", "overflow: scroll", "z-index: -1", "visibility: hidden", "width: 100%", "height: 100%"]);
+            const shrinkStyle             = buildCssTextString(["position: absolute", "flex: none", "overflow: scroll", "z-index: -1", "visibility: hidden", "width: 100%", "height: 100%"]);
+            const expandChildStyle        = buildCssTextString(["position: absolute", "left: 0", "top: 0"]);
+            const shrinkChildStyle        = buildCssTextString(["position: absolute", "width: 200%", "height: 200%"]);
 
-            var containerContainer      = document.createElement("div");
+            const containerContainer      = document.createElement("div");
             var container               = document.createElement("div");
-            var expand                  = document.createElement("div");
-            var expandChild             = document.createElement("div");
-            var shrink                  = document.createElement("div");
-            var shrinkChild             = document.createElement("div");
+            const expand                  = document.createElement("div");
+            const expandChild             = document.createElement("div");
+            const shrink                  = document.createElement("div");
+            const shrinkChild             = document.createElement("div");
 
             // Some browsers choke on the resize system being rtl, so force it to ltr. https://github.com/wnr/element-resize-detector/issues/56
             // However, dir should not be set on the top level container as it alters the dimensions of the target element in some browsers.
@@ -424,19 +424,19 @@ module.exports = function(options) {
 
         function registerListenersAndPositionElements() {
             function updateChildSizes(element, width, height) {
-                var expandChild             = getExpandChildElement(element);
-                var expandWidth             = getExpandWidth(width);
-                var expandHeight            = getExpandHeight(height);
+                const expandChild             = getExpandChildElement(element);
+                const expandWidth             = getExpandWidth(width);
+                const expandHeight            = getExpandHeight(height);
                 expandChild.style.setProperty("width", expandWidth + "px", options.important ? "important" : "");
                 expandChild.style.setProperty("height", expandHeight + "px", options.important ? "important" : "");
             }
 
             function updateDetectorElements(done) {
-                var width           = element.offsetWidth;
-                var height          = element.offsetHeight;
+                const width           = element.offsetWidth;
+                const height          = element.offsetHeight;
 
                 // Check whether the size has actually changed since last time the algorithm ran. If not, some steps may be skipped.
-                var sizeChanged = width !== getState(element).lastWidth || height !== getState(element).lastHeight;
+                const sizeChanged = width !== getState(element).lastWidth || height !== getState(element).lastHeight;
 
                 debug("Storing current size", width, height);
 
@@ -463,8 +463,8 @@ module.exports = function(options) {
                     }
 
                     if (options.debug) {
-                        var w = element.offsetWidth;
-                        var h = element.offsetHeight;
+                        const w = element.offsetWidth;
+                        const h = element.offsetHeight;
 
                         if (w !== width || h !== height) {
                             reporter.warn(idHandler.get(element), "Scroll: Size changed before updating detector elements.");
@@ -519,7 +519,7 @@ module.exports = function(options) {
 
                 debug("notifyListenersIfNeeded invoked");
 
-                var state = getState(element);
+                const state = getState(element);
 
                 // Don't notify if the current size is the start size, and this is the first notification.
                 if (isFirstNotify() && state.lastWidth === state.startSize.width && state.lastHeight === state.startSize.height) {
@@ -549,8 +549,8 @@ module.exports = function(options) {
                 }
 
                 debug("Element rendered.");
-                var expand = getExpandElement(element);
-                var shrink = getShrinkElement(element);
+                const expand = getExpandElement(element);
+                const shrink = getShrinkElement(element);
                 if (expand.scrollLeft === 0 || expand.scrollTop === 0 || shrink.scrollLeft === 0 || shrink.scrollTop === 0) {
                     debug("Scrollbars out of sync. Updating detector elements...");
                     updateDetectorElements(notifyListenersIfNeeded);
@@ -592,7 +592,7 @@ module.exports = function(options) {
                 return;
             }
 
-            var style = getState(element).style;
+            const style = getState(element).style;
             storeCurrentSize(element, style.width, style.height);
             positionScrollbars(element, style.width, style.height);
         }
@@ -632,7 +632,7 @@ module.exports = function(options) {
     }
 
     function uninstall(element) {
-        var state = getState(element);
+        const state = getState(element);
 
         if (!state) {
             // Uninstall has been called on a non-erd element.

--- a/src/detection-strategy/scroll.js
+++ b/src/detection-strategy/scroll.js
@@ -84,11 +84,14 @@ module.exports = function(options) {
         if (!targetDocument.getElementById(styleId)) {
             const containerAnimationClass = `${containerClass}_animation`;
             const containerAnimationActiveClass = `${containerClass}_animation_active`;
-            var style = "/* Created by the element-resize-detector library. */\n";
-            style += `.${containerClass} > div::-webkit-scrollbar { ${buildCssTextString(["display: none"])} }\n\n`;
-            style += `.${containerAnimationActiveClass} { ${buildCssTextString(["-webkit-animation-duration: 0.1s", "animation-duration: 0.1s", `-webkit-animation-name: ${containerAnimationClass}`, `animation-name: ${containerAnimationClass}`])} }\n`;
-            style += `@-webkit-keyframes ${containerAnimationClass} { 0% { opacity: 1; } 50% { opacity: 0; } 100% { opacity: 1; } }\n`;
-            style += `@keyframes ${containerAnimationClass} { 0% { opacity: 1; } 50% { opacity: 0; } 100% { opacity: 1; } }`;
+            const style =
+                `/* Created by the element-resize-detector library. */
+                .${containerClass} > div::-webkit-scrollbar { ${buildCssTextString(["display: none"])} }
+
+                .${containerAnimationActiveClass} { ${buildCssTextString(["-webkit-animation-duration: 0.1s", "animation-duration: 0.1s", `-webkit-animation-name: ${containerAnimationClass}`, `animation-name: ${containerAnimationClass}`])} }
+                @-webkit-keyframes ${containerAnimationClass} { 0% { opacity: 1; } 50% { opacity: 0; } 100% { opacity: 1; } }
+                @keyframes ${containerAnimationClass} { 0% { opacity: 1; } 50% { opacity: 0; } 100% { opacity: 1; } }
+                `;
             injectStyle(style);
         }
     }

--- a/src/detection-strategy/scroll.js
+++ b/src/detection-strategy/scroll.js
@@ -48,10 +48,10 @@ module.exports = function(options) {
         const height = 500;
 
         const child = document.createElement("div");
-        child.style.cssText = buildCssTextString(["position: absolute", "width: " + width*2 + "px", "height: " + height*2 + "px", "visibility: hidden", "margin: 0", "padding: 0"]);
+        child.style.cssText = buildCssTextString(["position: absolute", `width: ${width*2}px`, `height: ${height*2}px`, "visibility: hidden", "margin: 0", "padding: 0"]);
 
         const container = document.createElement("div");
-        container.style.cssText = buildCssTextString(["position: absolute", "width: " + width + "px", "height: " + height + "px", "overflow: scroll", "visibility: none", "top: " + -width*3 + "px", "left: " + -height*3 + "px", "visibility: hidden", "margin: 0", "padding: 0"]);
+        container.style.cssText = buildCssTextString(["position: absolute", `width: ${width}px`, `height: ${height}px`, "overflow: scroll", "visibility: none", `top: ${-width*3}px`, `left: ${-height*3}px`, "visibility: hidden", "margin: 0", "padding: 0"]);
 
         container.appendChild(child);
 
@@ -82,26 +82,26 @@ module.exports = function(options) {
         }
 
         if (!targetDocument.getElementById(styleId)) {
-            const containerAnimationClass = containerClass + "_animation";
-            const containerAnimationActiveClass = containerClass + "_animation_active";
+            const containerAnimationClass = `${containerClass}_animation`;
+            const containerAnimationActiveClass = `${containerClass}_animation_active`;
             var style = "/* Created by the element-resize-detector library. */\n";
-            style += "." + containerClass + " > div::-webkit-scrollbar { " + buildCssTextString(["display: none"]) + " }\n\n";
-            style += "." + containerAnimationActiveClass + " { " + buildCssTextString(["-webkit-animation-duration: 0.1s", "animation-duration: 0.1s", "-webkit-animation-name: " + containerAnimationClass, "animation-name: " + containerAnimationClass]) + " }\n";
-            style += "@-webkit-keyframes " + containerAnimationClass +  " { 0% { opacity: 1; } 50% { opacity: 0; } 100% { opacity: 1; } }\n";
-            style += "@keyframes " + containerAnimationClass +          " { 0% { opacity: 1; } 50% { opacity: 0; } 100% { opacity: 1; } }";
+            style += `.${containerClass} > div::-webkit-scrollbar { ${buildCssTextString(["display: none"])} }\n\n`;
+            style += `.${containerAnimationActiveClass} { ${buildCssTextString(["-webkit-animation-duration: 0.1s", "animation-duration: 0.1s", `-webkit-animation-name: ${containerAnimationClass}`, `animation-name: ${containerAnimationClass}`])} }\n`;
+            style += `@-webkit-keyframes ${containerAnimationClass} { 0% { opacity: 1; } 50% { opacity: 0; } 100% { opacity: 1; } }\n`;
+            style += `@keyframes ${containerAnimationClass} { 0% { opacity: 1; } 50% { opacity: 0; } 100% { opacity: 1; } }`;
             injectStyle(style);
         }
     }
 
     function addAnimationClass(element) {
-        element.className += " " + detectionContainerClass + "_animation_active";
+        element.className += ` ${detectionContainerClass}_animation_active`;
     }
 
     function addEvent(el, name, cb) {
         if (el.addEventListener) {
             el.addEventListener(name, cb);
         } else if(el.attachEvent) {
-            el.attachEvent("on" + name, cb);
+            el.attachEvent(`on${name}`, cb);
         } else {
             return reporter.error("[scroll] Don't know how to add event listeners.");
         }
@@ -111,7 +111,7 @@ module.exports = function(options) {
         if (el.removeEventListener) {
             el.removeEventListener(name, cb);
         } else if(el.detachEvent) {
-            el.detachEvent("on" + name, cb);
+            el.detachEvent(`on${name}`, cb);
         } else {
             return reporter.error("[scroll] Don't know how to remove event listeners.");
         }
@@ -323,7 +323,7 @@ module.exports = function(options) {
                         var value = style[property];
 
                         if(value !== "auto" && getNumericalValue(value) !== "0") {
-                            reporter.warn("An element that is positioned static has style." + property + "=" + value + " which is ignored due to the static positioning. The element will need to be positioned relative, so the style." + property + " will be set to 0. Element: ", element);
+                            reporter.warn(`An element that is positioned static has style.${property}=${value} which is ignored due to the static positioning. The element will need to be positioned relative, so the style.${property} will be set to 0. Element: `, element);
                             element.style[property] = 0;
                         }
                     };
@@ -338,12 +338,12 @@ module.exports = function(options) {
             }
 
             function getLeftTopBottomRightCssText(left, top, bottom, right) {
-                left = (!left ? "0" : (left + "px"));
-                top = (!top ? "0" : (top + "px"));
-                bottom = (!bottom ? "0" : (bottom + "px"));
-                right = (!right ? "0" : (right + "px"));
+                left = (!left ? "0" : (`${left}px`));
+                top = (!top ? "0" : (`${top}px`));
+                bottom = (!bottom ? "0" : (`${bottom}px`));
+                right = (!right ? "0" : (`${right}px`));
 
-                return ["left: " + left, "top: " + top, "right: " + right, "bottom: " + bottom];
+                return [`left: ${left}`, `top: ${top}`, `right: ${right}`, `bottom: ${bottom}`];
             }
 
             debug("Injecting elements");
@@ -427,8 +427,8 @@ module.exports = function(options) {
                 const expandChild             = getExpandChildElement(element);
                 const expandWidth             = getExpandWidth(width);
                 const expandHeight            = getExpandHeight(height);
-                expandChild.style.setProperty("width", expandWidth + "px", options.important ? "important" : "");
-                expandChild.style.setProperty("height", expandHeight + "px", options.important ? "important" : "");
+                expandChild.style.setProperty("width", `${expandWidth}px`, options.important ? "important" : "");
+                expandChild.style.setProperty("height", `${expandHeight}px`, options.important ? "important" : "");
             }
 
             function updateDetectorElements(done) {

--- a/src/element-resize-detector.js
+++ b/src/element-resize-detector.js
@@ -1,18 +1,18 @@
 "use strict";
 
-var forEach                 = require("./collection-utils").forEach;
-var elementUtilsMaker       = require("./element-utils");
-var listenerHandlerMaker    = require("./listener-handler");
-var idGeneratorMaker        = require("./id-generator");
-var idHandlerMaker          = require("./id-handler");
-var reporterMaker           = require("./reporter");
-var browserDetector         = require("./browser-detector");
-var batchProcessorMaker     = require("batch-processor");
-var stateHandler            = require("./state-handler");
+const forEach                 = require("./collection-utils").forEach;
+const elementUtilsMaker       = require("./element-utils");
+const listenerHandlerMaker    = require("./listener-handler");
+const idGeneratorMaker        = require("./id-generator");
+const idHandlerMaker          = require("./id-handler");
+const reporterMaker           = require("./reporter");
+const browserDetector         = require("./browser-detector");
+const batchProcessorMaker     = require("batch-processor");
+const stateHandler            = require("./state-handler");
 
 //Detection strategies.
-var objectStrategyMaker     = require("./detection-strategy/object.js");
-var scrollStrategyMaker     = require("./detection-strategy/scroll.js");
+const objectStrategyMaker     = require("./detection-strategy/object.js");
+const scrollStrategyMaker     = require("./detection-strategy/scroll.js");
 
 function isCollection(obj) {
     return Array.isArray(obj) || obj.length !== undefined;
@@ -20,7 +20,7 @@ function isCollection(obj) {
 
 function toArray(collection) {
     if (!Array.isArray(collection)) {
-        var array = [];
+        const array = [];
         forEach(collection, function (obj) {
             array.push(obj);
         });
@@ -64,7 +64,7 @@ module.exports = function(options) {
     options = options || {};
 
     //idHandler is currently not an option to the listenTo function, so it should not be added to globalOptions.
-    var idHandler;
+    let idHandler;
 
     if (options.idHandler) {
         // To maintain compatability with idHandler.get(element, readonly), make sure to wrap the given idHandler
@@ -74,8 +74,8 @@ module.exports = function(options) {
             set: options.idHandler.set
         };
     } else {
-        var idGenerator = idGeneratorMaker();
-        var defaultIdHandler = idHandlerMaker({
+        const idGenerator = idGeneratorMaker();
+        const defaultIdHandler = idHandlerMaker({
             idGenerator: idGenerator,
             stateHandler: stateHandler
         });
@@ -83,32 +83,32 @@ module.exports = function(options) {
     }
 
     //reporter is currently not an option to the listenTo function, so it should not be added to globalOptions.
-    var reporter = options.reporter;
+    let reporter = options.reporter;
 
     if(!reporter) {
         //If options.reporter is false, then the reporter should be quiet.
-        var quiet = reporter === false;
+        const quiet = reporter === false;
         reporter = reporterMaker(quiet);
     }
 
     //batchProcessor is currently not an option to the listenTo function, so it should not be added to globalOptions.
-    var batchProcessor = getOption(options, "batchProcessor", batchProcessorMaker({ reporter: reporter }));
+    const batchProcessor = getOption(options, "batchProcessor", batchProcessorMaker({ reporter: reporter }));
 
     //Options to be used as default for the listenTo function.
-    var globalOptions = {};
+    const globalOptions = {};
     globalOptions.callOnAdd     = !!getOption(options, "callOnAdd", true);
     globalOptions.debug         = !!getOption(options, "debug", false);
 
-    var eventListenerHandler    = listenerHandlerMaker(idHandler);
-    var elementUtils            = elementUtilsMaker({
+    const eventListenerHandler    = listenerHandlerMaker(idHandler);
+    const elementUtils            = elementUtilsMaker({
         stateHandler: stateHandler
     });
 
     //The detection strategy to be used.
-    var detectionStrategy;
-    var desiredStrategy = getOption(options, "strategy", "object");
-    var importantCssRules = getOption(options, "important", false);
-    var strategyOptions = {
+    let detectionStrategy;
+    let desiredStrategy = getOption(options, "strategy", "object");
+    const importantCssRules = getOption(options, "important", false);
+    const strategyOptions = {
         reporter: reporter,
         batchProcessor: batchProcessor,
         stateHandler: stateHandler,
@@ -139,7 +139,7 @@ module.exports = function(options) {
     //With this map, the ready callbacks can be synchronized between the calls
     //so that the ready callback can always be called when an element is ready - even if
     //it wasn't installed from the function itself.
-    var onReadyCallbacks = {};
+    const onReadyCallbacks = {};
 
     /**
      * Makes the given elements resize-detectable and starts listening to resize events on the elements. Calls the event callback for each event for each element.
@@ -150,7 +150,7 @@ module.exports = function(options) {
      */
     function listenTo(options, elements, listener) {
         function onResizeCallback(element) {
-            var listeners = eventListenerHandler.get(element);
+            const listeners = eventListenerHandler.get(element);
             forEach(listeners, function callListenerProxy(listener) {
                 listener(element);
             });
@@ -190,11 +190,11 @@ module.exports = function(options) {
             return reporter.error("Invalid arguments. Must be a DOM element or a collection of DOM elements.");
         }
 
-        var elementsReady = 0;
+        let elementsReady = 0;
 
         var callOnAdd = getOption(options, "callOnAdd", globalOptions.callOnAdd);
-        var onReadyCallback = getOption(options, "onReady", function noop() {});
-        var debug = getOption(options, "debug", globalOptions.debug);
+        const onReadyCallback = getOption(options, "onReady", function noop() {});
+        const debug = getOption(options, "debug", globalOptions.debug);
 
         forEach(elements, function attachListenerToElement(element) {
             if (!stateHandler.getState(element)) {
@@ -202,7 +202,7 @@ module.exports = function(options) {
                 idHandler.set(element);
             }
 
-            var id = idHandler.get(element);
+            const id = idHandler.get(element);
 
             debug && reporter.log("Attaching listener to element", id, element);
 
@@ -241,10 +241,10 @@ module.exports = function(options) {
                         // so that a resize event may be emitted.
                         // Having the startSize object is optional (since it does not make sense in some cases such as unrendered elements), so check for its existance before.
                         // Also, check the state existance before since the element may have been uninstalled in the installation process.
-                        var state = stateHandler.getState(element);
+                        const state = stateHandler.getState(element);
                         if (state && state.startSize) {
-                            var width = element.offsetWidth;
-                            var height = element.offsetHeight;
+                            const width = element.offsetWidth;
+                            const height = element.offsetHeight;
                             if (state.startSize.width !== width || state.startSize.height !== height) {
                                 onResizeCallback(element);
                             }
@@ -318,7 +318,7 @@ module.exports = function(options) {
 };
 
 function getOption(options, name, defaultValue) {
-    var value = options[name];
+    const value = options[name];
 
     if((value === undefined || value === null) && defaultValue !== undefined) {
         return defaultValue;

--- a/src/element-resize-detector.js
+++ b/src/element-resize-detector.js
@@ -131,7 +131,7 @@ module.exports = function(options) {
     } else if(desiredStrategy === "object") {
         detectionStrategy = objectStrategyMaker(strategyOptions);
     } else {
-        throw new Error("Invalid strategy name: " + desiredStrategy);
+        throw new Error(`Invalid strategy name: ${desiredStrategy}`);
     }
 
     //Calls can be made to listenTo with elements that are still being installed.

--- a/src/element-resize-detector.js
+++ b/src/element-resize-detector.js
@@ -70,14 +70,14 @@ module.exports = function(options) {
         // To maintain compatability with idHandler.get(element, readonly), make sure to wrap the given idHandler
         // so that readonly flag always is true when it's used here. This may be removed next major version bump.
         idHandler = {
-            get: function (element) { return options.idHandler.get(element, true); },
+            get(element) { return options.idHandler.get(element, true); },
             set: options.idHandler.set
         };
     } else {
         const idGenerator = idGeneratorMaker();
         const defaultIdHandler = idHandlerMaker({
-            idGenerator: idGenerator,
-            stateHandler: stateHandler
+            idGenerator,
+            stateHandler
         });
         idHandler = defaultIdHandler;
     }
@@ -92,7 +92,7 @@ module.exports = function(options) {
     }
 
     //batchProcessor is currently not an option to the listenTo function, so it should not be added to globalOptions.
-    const batchProcessor = getOption(options, "batchProcessor", batchProcessorMaker({ reporter: reporter }));
+    const batchProcessor = getOption(options, "batchProcessor", batchProcessorMaker({ reporter }));
 
     //Options to be used as default for the listenTo function.
     const globalOptions = {};
@@ -101,7 +101,7 @@ module.exports = function(options) {
 
     const eventListenerHandler    = listenerHandlerMaker(idHandler);
     const elementUtils            = elementUtilsMaker({
-        stateHandler: stateHandler
+        stateHandler
     });
 
     //The detection strategy to be used.
@@ -109,10 +109,10 @@ module.exports = function(options) {
     let desiredStrategy = getOption(options, "strategy", "object");
     const importantCssRules = getOption(options, "important", false);
     const strategyOptions = {
-        reporter: reporter,
-        batchProcessor: batchProcessor,
-        stateHandler: stateHandler,
-        idHandler: idHandler,
+        reporter,
+        batchProcessor,
+        stateHandler,
+        idHandler,
         important: importantCssRules
     };
 
@@ -228,7 +228,7 @@ module.exports = function(options) {
                 debug && reporter.log(id, "Making detectable...");
                 //The element is not prepared to be detectable, so do prepare it and add a listener to it.
                 elementUtils.markBusy(element, true);
-                return detectionStrategy.makeDetectable({ debug: debug, important: importantCssRules }, element, function onElementDetectable(element) {
+                return detectionStrategy.makeDetectable({ debug, important: importantCssRules }, element, function onElementDetectable(element) {
                     debug && reporter.log(id, "onElementDetectable");
 
                     if (stateHandler.getState(element)) {
@@ -309,11 +309,11 @@ module.exports = function(options) {
     }
 
     return {
-        listenTo: listenTo,
+        listenTo,
         removeListener: eventListenerHandler.removeListener,
         removeAllListeners: eventListenerHandler.removeAllListeners,
-        uninstall: uninstall,
-        initDocument: initDocument
+        uninstall,
+        initDocument
     };
 };
 

--- a/src/element-utils.js
+++ b/src/element-utils.js
@@ -44,9 +44,9 @@ module.exports = function(options) {
     }
 
     return {
-        isDetectable: isDetectable,
-        markAsDetectable: markAsDetectable,
-        isBusy: isBusy,
-        markBusy: markBusy
+        isDetectable,
+        markAsDetectable,
+        isBusy,
+        markBusy
     };
 };

--- a/src/element-utils.js
+++ b/src/element-utils.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = function(options) {
-    var getState = options.stateHandler.getState;
+    const getState = options.stateHandler.getState;
 
     /**
      * Tells if the element has been made detectable and ready to be listened for resize events.
@@ -10,7 +10,7 @@ module.exports = function(options) {
      * @returns {boolean} True or false depending on if the element is detectable or not.
      */
     function isDetectable(element) {
-        var state = getState(element);
+        const state = getState(element);
         return state && !!state.isDetectable;
     }
 

--- a/src/id-generator.js
+++ b/src/id-generator.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = function() {
-    var idCount = 1;
+    let idCount = 1;
 
     /**
      * Generates a new unique id in the context.

--- a/src/id-generator.js
+++ b/src/id-generator.js
@@ -13,6 +13,6 @@ module.exports = function() {
     }
 
     return {
-        generate: generate
+        generate
     };
 };

--- a/src/id-handler.js
+++ b/src/id-handler.js
@@ -1,8 +1,8 @@
 "use strict";
 
 module.exports = function(options) {
-    var idGenerator     = options.idGenerator;
-    var getState        = options.stateHandler.getState;
+    const idGenerator     = options.idGenerator;
+    const getState        = options.stateHandler.getState;
 
     /**
      * Gets the resize detector id of the element.
@@ -11,7 +11,7 @@ module.exports = function(options) {
      * @returns {string|number|null} The id of the element. Null if it has no id.
      */
     function getId(element) {
-        var state = getState(element);
+        const state = getState(element);
 
         if (state && state.id !== undefined) {
             return state.id;
@@ -27,13 +27,13 @@ module.exports = function(options) {
      * @returns {string|number|null} The id of the element.
      */
     function setId(element) {
-        var state = getState(element);
+        const state = getState(element);
 
         if (!state) {
             throw new Error("setId required the element to have a resize detection state.");
         }
 
-        var id = idGenerator.generate();
+        const id = idGenerator.generate();
 
         state.id = id;
 

--- a/src/listener-handler.js
+++ b/src/listener-handler.js
@@ -54,7 +54,7 @@ module.exports = function(idHandler) {
     return {
         get: getListeners,
         add: addListener,
-        removeListener: removeListener,
-        removeAllListeners: removeAllListeners
+        removeListener,
+        removeAllListeners
     };
 };

--- a/src/listener-handler.js
+++ b/src/listener-handler.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = function(idHandler) {
-    var eventListeners = {};
+    const eventListeners = {};
 
     /**
      * Gets all listeners for the given element.
@@ -10,7 +10,7 @@ module.exports = function(idHandler) {
      * @returns All listeners for the given element.
      */
     function getListeners(element) {
-        var id = idHandler.get(element);
+        const id = idHandler.get(element);
 
         if (id === undefined) {
             return [];
@@ -26,7 +26,7 @@ module.exports = function(idHandler) {
      * @param {function} listener The callback that the element has added.
      */
     function addListener(element, listener) {
-        var id = idHandler.get(element);
+        const id = idHandler.get(element);
 
         if(!eventListeners[id]) {
             eventListeners[id] = [];
@@ -36,8 +36,8 @@ module.exports = function(idHandler) {
     }
 
     function removeListener(element, listener) {
-        var listeners = getListeners(element);
-        for (var i = 0, len = listeners.length; i < len; ++i) {
+        const listeners = getListeners(element);
+        for (let i = 0, len = listeners.length; i < len; ++i) {
             if (listeners[i] === listener) {
               listeners.splice(i, 1);
               break;
@@ -46,7 +46,7 @@ module.exports = function(idHandler) {
     }
 
     function removeAllListeners(element) {
-      var listeners = getListeners(element);
+      const listeners = getListeners(element);
       if (!listeners) { return; }
       listeners.length = 0;
     }

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -12,22 +12,22 @@ module.exports = function(quiet) {
         //Does nothing.
     }
 
-    var reporter = {
+    const reporter = {
         log: noop,
         warn: noop,
         error: noop
     };
 
     if(!quiet && window.console) {
-        var attachFunction = function(reporter, name) {
+        const attachFunction = function(reporter, name) {
             //The proxy is needed to be able to call the method with the console context,
             //since we cannot use bind.
             reporter[name] = function reporterProxy() {
-                var f = console[name];
+                const f = console[name];
                 if (f.apply) { //IE9 does not support console.log.apply :)
                     f.apply(console, arguments);
                 } else {
-                    for (var i = 0; i < arguments.length; i++) {
+                    for (let i = 0; i < arguments.length; i++) {
                         f(arguments[i]);
                     }
                 }

--- a/src/state-handler.js
+++ b/src/state-handler.js
@@ -16,7 +16,7 @@ function cleanState(element) {
 }
 
 module.exports = {
-    initState: initState,
-    getState: getState,
-    cleanState: cleanState
+    initState,
+    getState,
+    cleanState
 };

--- a/src/state-handler.js
+++ b/src/state-handler.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var prop = "_erd";
+const prop = "_erd";
 
 function initState(element) {
     element[prop] = {};

--- a/test/element-resize-detector_test.js
+++ b/test/element-resize-detector_test.js
@@ -3,20 +3,20 @@
 "use strict";
 
 function ensureMapEqual(before, after, ignore) {
-    var beforeKeys = _.keys(before);
-    var afterKeys = _.keys(after);
+    const beforeKeys = _.keys(before);
+    const afterKeys = _.keys(after);
 
-    var unionKeys = _.union(beforeKeys, afterKeys);
+    const unionKeys = _.union(beforeKeys, afterKeys);
 
-    var diffValueKeys = _.filter(unionKeys, function (key) {
-        var beforeValue = before[key];
-        var afterValue = after[key];
+    const diffValueKeys = _.filter(unionKeys, function (key) {
+        const beforeValue = before[key];
+        const afterValue = after[key];
         return !ignore(key, beforeValue, afterValue) && beforeValue !== afterValue;
     });
 
     if (diffValueKeys.length) {
-        var beforeDiffObject = {};
-        var afterDiffObject = {};
+        const beforeDiffObject = {};
+        const afterDiffObject = {};
 
         _.forEach(diffValueKeys, function (key) {
             beforeDiffObject[key] = before[key];
@@ -29,10 +29,10 @@ function ensureMapEqual(before, after, ignore) {
 
 function getStyle(element) {
     function clone(styleObject) {
-        var clonedTarget = {};
+        const clonedTarget = {};
         _.forEach(styleObject.cssText.split(";").slice(0, -1), function (declaration) {
-            var colonPos = declaration.indexOf(":");
-            var attr = declaration.slice(0, colonPos).trim();
+            const colonPos = declaration.indexOf(":");
+            const attr = declaration.slice(0, colonPos).trim();
             if (attr.indexOf("-") === -1) { // Remove attributes like "background-image", leaving "backgroundImage"
                 clonedTarget[attr] = declaration.slice(colonPos + 2);
             }
@@ -40,21 +40,21 @@ function getStyle(element) {
         return clonedTarget;
     }
 
-    var style = getComputedStyle(element);
+    const style = getComputedStyle(element);
     return clone(style);
 }
 
 function getAttributes(element) {
-    var attrs = {};
+    const attrs = {};
     _.forEach(element.attributes, function (attr) {
         attrs[attr.nodeName] = attr.value;
     });
     return attrs;
 }
 
-var ensureAttributes = ensureMapEqual;
+const ensureAttributes = ensureMapEqual;
 
-var reporter = {
+const reporter = {
     log: function () {
         throw new Error("Reporter.log should not be called");
     },
@@ -71,13 +71,13 @@ $("body").prepend("<div id=fixtures></div>");
 function listenToTest(strategy) {
     describe("[" + strategy + "] listenTo", function () {
         it("should be able to attach a listener to an element", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
                 reporter: reporter,
                 strategy: strategy
             });
 
-            var listener = jasmine.createSpy("listener");
+            const listener = jasmine.createSpy("listener");
 
             erd.listenTo($("#test")[0], listener);
 
@@ -92,7 +92,7 @@ function listenToTest(strategy) {
         });
 
         it("should throw on invalid parameters", function () {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
                 reporter: reporter,
                 strategy: strategy
@@ -105,13 +105,13 @@ function listenToTest(strategy) {
 
         describe("option.onReady", function () {
             it("should be called when installing a listener to an element", function (done) {
-                var erd = elementResizeDetectorMaker({
+                const erd = elementResizeDetectorMaker({
                     callOnAdd: false,
                     reporter: reporter,
                     strategy: strategy
                 });
 
-                var listener = jasmine.createSpy("listener");
+                const listener = jasmine.createSpy("listener");
 
                 erd.listenTo({
                     onReady: function () {
@@ -125,13 +125,13 @@ function listenToTest(strategy) {
             });
 
             it("should be called when all elements are ready", function (done) {
-                var erd = elementResizeDetectorMaker({
+                const erd = elementResizeDetectorMaker({
                     callOnAdd: false,
                     reporter: reporter,
                     strategy: strategy
                 });
 
-                var listener = jasmine.createSpy("listener");
+                const listener = jasmine.createSpy("listener");
 
                 erd.listenTo({
                     onReady: function () {
@@ -147,14 +147,14 @@ function listenToTest(strategy) {
             });
 
             it("should be able to handle listeners for the same element but different calls", function (done) {
-                var erd = elementResizeDetectorMaker({
+                const erd = elementResizeDetectorMaker({
                     callOnAdd: false,
                     reporter: reporter,
                     strategy: strategy
                 });
 
-                var onReady1 = jasmine.createSpy("listener");
-                var onReady2 = jasmine.createSpy("listener");
+                const onReady1 = jasmine.createSpy("listener");
+                const onReady2 = jasmine.createSpy("listener");
 
                 erd.listenTo({
                     onReady: onReady1
@@ -173,14 +173,14 @@ function listenToTest(strategy) {
             });
 
             it("should be able to handle when elements occur multiple times in the same call (and other calls)", function (done) {
-                var erd = elementResizeDetectorMaker({
+                const erd = elementResizeDetectorMaker({
                     callOnAdd: false,
                     reporter: reporter,
                     strategy: strategy
                 });
 
-                var onReady1 = jasmine.createSpy("listener");
-                var onReady2 = jasmine.createSpy("listener");
+                const onReady1 = jasmine.createSpy("listener");
+                const onReady2 = jasmine.createSpy("listener");
 
                 erd.listenTo({
                     onReady: onReady1
@@ -200,14 +200,14 @@ function listenToTest(strategy) {
         });
 
         it("should be able to attach multiple listeners to an element", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
                 reporter: reporter,
                 strategy: strategy
             });
 
-            var listener1 = jasmine.createSpy("listener1");
-            var listener2 = jasmine.createSpy("listener2");
+            const listener1 = jasmine.createSpy("listener1");
+            const listener2 = jasmine.createSpy("listener2");
 
             erd.listenTo($("#test")[0], listener1);
             erd.listenTo($("#test")[0], listener2);
@@ -224,13 +224,13 @@ function listenToTest(strategy) {
         });
 
         it("should be able to attach a listener to an element multiple times within the same call", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
                 reporter: reporter,
                 strategy: strategy
             });
 
-            var listener1 = jasmine.createSpy("listener1");
+            const listener1 = jasmine.createSpy("listener1");
 
             erd.listenTo([$("#test")[0], $("#test")[0]], listener1);
 
@@ -246,13 +246,13 @@ function listenToTest(strategy) {
         });
 
         it("should be able to attach listeners to multiple elements", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
                 reporter: reporter,
                 strategy: strategy
             });
 
-            var listener1 = jasmine.createSpy("listener1");
+            const listener1 = jasmine.createSpy("listener1");
 
             erd.listenTo($("#test, #test2"), listener1);
 
@@ -278,7 +278,7 @@ function listenToTest(strategy) {
         //Only IE8 is lacking the getComputedStyle method.
         if (window.getComputedStyle) {
             it("should keep the style of the element intact", function (done) {
-                var erd = elementResizeDetectorMaker({
+                const erd = elementResizeDetectorMaker({
                     callOnAdd: false,
                     reporter: reporter,
                     strategy: strategy
@@ -289,14 +289,14 @@ function listenToTest(strategy) {
                         (/^(top|right|bottom|left)$/.test(key) && before === "auto" && after === "0px");
                 }
 
-                var beforeComputedStyle = getStyle($("#test")[0]);
+                const beforeComputedStyle = getStyle($("#test")[0]);
                 erd.listenTo($("#test")[0], _.noop);
-                var afterComputedStyle = getStyle($("#test")[0]);
+                const afterComputedStyle = getStyle($("#test")[0]);
                 ensureMapEqual(beforeComputedStyle, afterComputedStyle, ignoreStyleChange);
 
                 //Test styles async since making an element listenable is async.
                 setTimeout(function () {
-                    var afterComputedStyleAsync = getStyle($("#test")[0]);
+                    const afterComputedStyleAsync = getStyle($("#test")[0]);
                     ensureMapEqual(beforeComputedStyle, afterComputedStyleAsync, ignoreStyleChange);
                     expect(true).toEqual(true); // Needed so that jasmine does not warn about no expects in the test (the actual expects are in the ensureMapEqual).
                     done();
@@ -306,13 +306,13 @@ function listenToTest(strategy) {
 
         describe("options.callOnAdd", function () {
             it("should be true default and call all functions when listenTo succeeds", function (done) {
-                var erd = elementResizeDetectorMaker({
+                const erd = elementResizeDetectorMaker({
                     reporter: reporter,
                     strategy: strategy
                 });
 
-                var listener = jasmine.createSpy("listener");
-                var listener2 = jasmine.createSpy("listener2");
+                const listener = jasmine.createSpy("listener");
+                const listener2 = jasmine.createSpy("listener2");
 
                 erd.listenTo($("#test")[0], listener);
                 erd.listenTo($("#test")[0], listener2);
@@ -333,12 +333,12 @@ function listenToTest(strategy) {
             });
 
             it("should call listener multiple times when listening to multiple elements", function (done) {
-                var erd = elementResizeDetectorMaker({
+                const erd = elementResizeDetectorMaker({
                     reporter: reporter,
                     strategy: strategy
                 });
 
-                var listener1 = jasmine.createSpy("listener1");
+                const listener1 = jasmine.createSpy("listener1");
                 erd.listenTo($("#test, #test2"), listener1);
 
                 setTimeout(function () {
@@ -350,13 +350,13 @@ function listenToTest(strategy) {
         });
 
         it("should call listener if the element is changed synchronously after listenTo", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
                 reporter: reporter,
                 strategy: strategy
             });
 
-            var listener1 = jasmine.createSpy("listener1");
+            const listener1 = jasmine.createSpy("listener1");
             erd.listenTo($("#test"), listener1);
             $("#test").width(200);
 
@@ -367,13 +367,13 @@ function listenToTest(strategy) {
         });
 
         it("should not emit resize when listenTo is called", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
                 reporter: reporter,
                 strategy: strategy
             });
 
-            var listener1 = jasmine.createSpy("listener1");
+            const listener1 = jasmine.createSpy("listener1");
             erd.listenTo($("#test"), listener1);
 
             setTimeout(function () {
@@ -383,13 +383,13 @@ function listenToTest(strategy) {
         });
 
         it("should not emit resize event even though the element is back to its start size", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
                 reporter: reporter,
                 strategy: strategy
             });
 
-            var listener = jasmine.createSpy("listener1");
+            const listener = jasmine.createSpy("listener1");
             $("#test").width(200);
             erd.listenTo($("#test"), listener);
 
@@ -412,9 +412,9 @@ function listenToTest(strategy) {
         });
 
         it("should use the option.idHandler if present", function (done) {
-            var ID_ATTR = "some-fancy-id-attr";
+            const ID_ATTR = "some-fancy-id-attr";
 
-            var idHandler = {
+            const idHandler = {
                 get: function (element, readonly) {
                     if (element[ID_ATTR] === undefined) {
                         if (readonly) {
@@ -427,7 +427,7 @@ function listenToTest(strategy) {
                     return $(element).attr(ID_ATTR);
                 },
                 set: function (element) {
-                    var id;
+                    let id;
 
                     if ($(element).attr("id") === "test") {
                         id = "test+1";
@@ -441,26 +441,26 @@ function listenToTest(strategy) {
                 }
             };
 
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 idHandler: idHandler,
                 callOnAdd: false,
                 reporter: reporter,
                 strategy: strategy
             });
 
-            var listener1 = jasmine.createSpy("listener1");
-            var listener2 = jasmine.createSpy("listener1");
+            const listener1 = jasmine.createSpy("listener1");
+            const listener2 = jasmine.createSpy("listener1");
 
-            var attrsBeforeTest = getAttributes($("#test")[0]);
-            var attrsBeforeTest2 = getAttributes($("#test2")[0]);
+            const attrsBeforeTest = getAttributes($("#test")[0]);
+            const attrsBeforeTest2 = getAttributes($("#test2")[0]);
 
             erd.listenTo($("#test"), listener1);
             erd.listenTo($("#test, #test2"), listener2);
 
-            var attrsAfterTest = getAttributes($("#test")[0]);
-            var attrsAfterTest2 = getAttributes($("#test2")[0]);
+            const attrsAfterTest = getAttributes($("#test")[0]);
+            const attrsAfterTest2 = getAttributes($("#test2")[0]);
 
-            var ignoreValidIdAttrAndStyle = function (key) {
+            const ignoreValidIdAttrAndStyle = function (key) {
                 return key === ID_ATTR || key === "style";
             };
 
@@ -484,14 +484,14 @@ function listenToTest(strategy) {
         });
 
         it("should be able to install into elements that are detached from the DOM", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
                 reporter: reporter,
                 strategy: strategy
             });
 
-            var listener1 = jasmine.createSpy("listener1");
-            var div = document.createElement("div");
+            const listener1 = jasmine.createSpy("listener1");
+            const div = document.createElement("div");
             div.style.width = "100%";
             div.style.height = "100%";
             erd.listenTo(div, listener1);
@@ -511,17 +511,17 @@ function listenToTest(strategy) {
         });
 
         it("should handle iframes, by using initDocument", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
                 strategy: strategy,
                 reporter: reporter
             });
 
-            var listener1 = jasmine.createSpy("listener1");
-            var iframe = document.createElement("iframe");
+            const listener1 = jasmine.createSpy("listener1");
+            const iframe = document.createElement("iframe");
             $("#test")[0].appendChild(iframe);
             erd.initDocument(iframe.contentDocument);
-            var div = iframe.contentDocument.createElement("div");
+            const div = iframe.contentDocument.createElement("div");
 
             div.style.width = "100%";
             div.style.height = "100%";
@@ -545,13 +545,13 @@ function listenToTest(strategy) {
         });
 
         it("should detect resizes caused by padding and font-size changes", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
                 reporter: reporter,
                 strategy: strategy
             });
 
-            var listener = jasmine.createSpy("listener");
+            const listener = jasmine.createSpy("listener");
             $("#test").html("test");
             $("#test").css("padding", "0px");
             $("#test").css("font-size", "16px");
@@ -574,7 +574,7 @@ function listenToTest(strategy) {
 
         describe("should handle unrendered elements correctly", function () {
             it("when installing", function (done) {
-                var erd = elementResizeDetectorMaker({
+                const erd = elementResizeDetectorMaker({
                     callOnAdd: false,
                     reporter: reporter,
                     strategy: strategy
@@ -583,7 +583,7 @@ function listenToTest(strategy) {
                 $("#test").html("<div id=\"inner\"></div>");
                 $("#test").css("display", "none");
 
-                var listener = jasmine.createSpy("listener");
+                const listener = jasmine.createSpy("listener");
                 erd.listenTo($("#inner"), listener);
 
                 setTimeout(function () {
@@ -605,7 +605,7 @@ function listenToTest(strategy) {
             });
 
             it("when element gets unrendered after installation", function (done) {
-                var erd = elementResizeDetectorMaker({
+                const erd = elementResizeDetectorMaker({
                     callOnAdd: false,
                     reporter: reporter,
                     strategy: strategy
@@ -614,7 +614,7 @@ function listenToTest(strategy) {
                 // The div is rendered to begin with.
                 $("#test").html("<div id=\"inner\"></div>");
 
-                var listener = jasmine.createSpy("listener");
+                const listener = jasmine.createSpy("listener");
                 erd.listenTo($("#inner"), listener);
 
                 // The it gets unrendered, and it changes width.
@@ -640,7 +640,7 @@ function listenToTest(strategy) {
 
         describe("inline elements", function () {
             it("should be listenable", function (done) {
-                var erd = elementResizeDetectorMaker({
+                const erd = elementResizeDetectorMaker({
                     callOnAdd: false,
                     reporter: reporter,
                     strategy: strategy
@@ -648,7 +648,7 @@ function listenToTest(strategy) {
 
                 $("#test").html("<span id=\"inner\">test</span>");
 
-                var listener = jasmine.createSpy("listener");
+                const listener = jasmine.createSpy("listener");
                 erd.listenTo($("#inner"), listener);
 
                 setTimeout(function () {
@@ -663,7 +663,7 @@ function listenToTest(strategy) {
             });
 
             it("should not get altered dimensions", function (done) {
-                var erd = elementResizeDetectorMaker({
+                const erd = elementResizeDetectorMaker({
                     callOnAdd: false,
                     reporter: reporter,
                     strategy: strategy
@@ -671,10 +671,10 @@ function listenToTest(strategy) {
 
                 $("#test").html("<span id=\"inner\"></span>");
 
-                var widthBefore = $("#inner").width();
-                var heightBefore = $("#inner").height();
+                const widthBefore = $("#inner").width();
+                const heightBefore = $("#inner").height();
 
-                var listener = jasmine.createSpy("listener");
+                const listener = jasmine.createSpy("listener");
                 erd.listenTo($("#inner"), listener);
 
                 setTimeout(function () {
@@ -686,13 +686,13 @@ function listenToTest(strategy) {
         });
 
         it("should handle dir=rtl correctly", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
                 reporter: reporter,
                 strategy: strategy
             });
 
-            var listener = jasmine.createSpy("listener");
+            const listener = jasmine.createSpy("listener");
 
             $("#test")[0].dir = "rtl";
             erd.listenTo($("#test")[0], listener);
@@ -708,13 +708,13 @@ function listenToTest(strategy) {
         });
 
         it("should handle fast consecutive resizes", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
                 strategy: strategy,
                 reporter: reporter
             });
 
-            var listener = jasmine.createSpy("listener");
+            const listener = jasmine.createSpy("listener");
 
             $("#test").width(100);
             erd.listenTo($("#test")[0], listener);
@@ -735,19 +735,19 @@ function listenToTest(strategy) {
             // So the resize events may be 1 or 3 at this point.
 
             setTimeout(function () {
-                var count = listener.calls.count();
+                const count = listener.calls.count();
                 expect(count === 1 || count === 3).toEqual(true);
             }, 150);
 
 
             setTimeout(function () {
-                var count = listener.calls.count();
+                const count = listener.calls.count();
                 expect(count === 1 || count === 3).toEqual(true);
                 $("#test").width(800);
             }, 200);
 
             setTimeout(function () {
-                var count = listener.calls.count();
+                const count = listener.calls.count();
                 expect(count === 2 || count === 4).toEqual(true);
                 done();
             }, 250);
@@ -759,15 +759,15 @@ function listenToTest(strategy) {
 function removalTest(strategy) {
     describe("[" + strategy + "] resizeDetector.removeListener", function () {
         it("should remove listener from element", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
                 strategy: strategy
             });
 
-            var $testElem = $("#test");
+            const $testElem = $("#test");
 
-            var listenerCall = jasmine.createSpy("listener");
-            var listenerNotCall = jasmine.createSpy("listener");
+            const listenerCall = jasmine.createSpy("listener");
+            const listenerNotCall = jasmine.createSpy("listener");
 
             erd.listenTo($testElem[0], listenerCall);
             erd.listenTo($testElem[0], listenerNotCall);
@@ -787,15 +787,15 @@ function removalTest(strategy) {
 
     describe("[" + strategy + "] resizeDetector.removeAllListeners", function () {
         it("should remove all listeners from element", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
                 strategy: strategy
             });
 
-            var $testElem = $("#test");
+            const $testElem = $("#test");
 
-            var listener1 = jasmine.createSpy("listener");
-            var listener2 = jasmine.createSpy("listener");
+            const listener1 = jasmine.createSpy("listener");
+            const listener2 = jasmine.createSpy("listener");
 
             erd.listenTo($testElem[0], listener1);
             erd.listenTo($testElem[0], listener2);
@@ -813,29 +813,29 @@ function removalTest(strategy) {
         });
 
         it("should work for elements that don't have the detector installed", function () {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 strategy: strategy
             });
-            var $testElem = $("#test");
+            const $testElem = $("#test");
             expect(erd.removeAllListeners.bind(erd, $testElem[0])).not.toThrow();
         });
     });
 
     describe("[scroll] Specific scenarios", function () {
         it("should be able to call uninstall in the middle of a resize", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 strategy: "scroll"
             });
 
-            var $testElem = $("#test");
-            var testElem = $testElem[0];
-            var listener = jasmine.createSpy("listener");
+            const $testElem = $("#test");
+            const testElem = $testElem[0];
+            const listener = jasmine.createSpy("listener");
 
             erd.listenTo(testElem, listener);
             setTimeout(function () {
                 // We want the uninstall to happen exactly when a scroll event occured before the delayed batched is going to be processed.
                 // So we intercept the erd shrink/expand functions in the state so that we may call uninstall after the handling of the event.
-                var uninstalled = false;
+                let uninstalled = false;
 
                 function wrapOnScrollEvent(oldFn) {
                     return function () {
@@ -848,7 +848,7 @@ function removalTest(strategy) {
                     };
                 }
 
-                var state = testElem._erd;
+                const state = testElem._erd;
                 state.onExpand = wrapOnScrollEvent(state.onExpand);
                 state.onShrink = wrapOnScrollEvent(state.onShrink);
                 $("#test").width(300);
@@ -856,20 +856,20 @@ function removalTest(strategy) {
         });
 
         it("should be able to call uninstall and then install in the middle of a resize (issue #61)", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 strategy: "scroll",
                 reporter: reporter
             });
 
-            var $testElem = $("#test");
-            var testElem = $testElem[0];
-            var listener = jasmine.createSpy("listener");
+            const $testElem = $("#test");
+            const testElem = $testElem[0];
+            const listener = jasmine.createSpy("listener");
 
             erd.listenTo(testElem, listener);
             setTimeout(function () {
                 // We want the uninstall to happen exactly when a scroll event occured before the delayed batched is going to be processed.
                 // So we intercept the erd shrink/expand functions in the state so that we may call uninstall after the handling of the event.
-                var uninstalled = false;
+                let uninstalled = false;
 
                 function wrapOnScrollEvent(oldFn) {
                     return function () {
@@ -877,7 +877,7 @@ function removalTest(strategy) {
                         if (!uninstalled) {
                             expect(erd.uninstall.bind(erd, testElem)).not.toThrow();
                             uninstalled = true;
-                            var listener2 = jasmine.createSpy("listener");
+                            const listener2 = jasmine.createSpy("listener");
                             expect(erd.listenTo.bind(erd, testElem, listener2)).not.toThrow();
                             setTimeout(function () {
                                 done();
@@ -886,7 +886,7 @@ function removalTest(strategy) {
                     };
                 }
 
-                var state = testElem._erd;
+                const state = testElem._erd;
                 state.onExpand = wrapOnScrollEvent(state.onExpand);
                 state.onShrink = wrapOnScrollEvent(state.onShrink);
                 $("#test").width(300);
@@ -896,17 +896,17 @@ function removalTest(strategy) {
         // Only run this shadow DOM test for browsers that support the feature
         if (!!HTMLElement.prototype.attachShadow) {
             it("should work for elements within an open shadow root (issue #127)", function(done) {
-                var erd = elementResizeDetectorMaker({
+                const erd = elementResizeDetectorMaker({
                     callOnAdd: false,
                     reporter: reporter,
                     strategy: "scroll"
                 });
 
-                var listener = jasmine.createSpy("listener");
+                const listener = jasmine.createSpy("listener");
 
                 // Setup shadow root with a child div
-                var shadow = $("#shadowtest")[0].attachShadow({mode: "open"});
-                var shadowChild = document.createElement("div");
+                const shadow = $("#shadowtest")[0].attachShadow({mode: "open"});
+                const shadowChild = document.createElement("div");
                 shadow.appendChild(shadowChild);
 
                 erd.listenTo(shadowChild, listener);
@@ -925,14 +925,14 @@ function removalTest(strategy) {
 
     describe("[" + strategy + "] resizeDetector.uninstall", function () {
         it("should completely remove detector from element", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
                 strategy: strategy
             });
 
-            var $testElem = $("#test");
+            const $testElem = $("#test");
 
-            var listener = jasmine.createSpy("listener");
+            const listener = jasmine.createSpy("listener");
 
             erd.listenTo($testElem[0], listener);
 
@@ -950,12 +950,12 @@ function removalTest(strategy) {
         });
 
         it("should completely remove detector from multiple elements", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
                 strategy: strategy
             });
 
-            var listener = jasmine.createSpy("listener");
+            const listener = jasmine.createSpy("listener");
 
             erd.listenTo($("#test, #test2"), listener);
 
@@ -974,24 +974,24 @@ function removalTest(strategy) {
         });
 
         it("should be able to call uninstall directly after listenTo", function () {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 strategy: strategy
             });
 
-            var $testElem = $("#test");
-            var listener = jasmine.createSpy("listener");
+            const $testElem = $("#test");
+            const listener = jasmine.createSpy("listener");
 
             erd.listenTo($testElem[0], listener);
             expect(erd.uninstall.bind(erd, $testElem[0])).not.toThrow();
         });
 
         it("should be able to call uninstall directly async after listenTo", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 strategy: strategy
             });
 
-            var $testElem = $("#test");
-            var listener = jasmine.createSpy("listener");
+            const $testElem = $("#test");
+            const listener = jasmine.createSpy("listener");
 
             erd.listenTo($testElem[0], listener);
             setTimeout(function () {
@@ -1001,14 +1001,14 @@ function removalTest(strategy) {
         });
 
         it("should be able to call uninstall in callOnAdd callback", function (done) {
-            var error = false;
+            let error = false;
 
             // Ugly hack to catch async errors.
             window.onerror = function () {
                 error = true;
             };
 
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 strategy: strategy,
                 callOnAdd: true
             });
@@ -1025,19 +1025,19 @@ function removalTest(strategy) {
         });
 
         it("should be able to call uninstall in callOnAdd callback with multiple elements", function (done) {
-            var error = false;
+            let error = false;
 
             // Ugly hack to catch async errors.
             window.onerror = function () {
                 error = true;
             };
 
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 strategy: strategy,
                 callOnAdd: true
             });
 
-            var listener = jasmine.createSpy("listener");
+            const listener = jasmine.createSpy("listener");
 
             erd.listenTo($("#test, #test2"), function () {
                 expect(erd.uninstall.bind(null, ($("#test, #test2")))).not.toThrow();
@@ -1053,15 +1053,15 @@ function removalTest(strategy) {
         });
 
         it("should be able to call uninstall on non-erd elements", function () {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 strategy: strategy
             });
 
-            var $testElem = $("#test");
+            const $testElem = $("#test");
 
             expect(erd.uninstall.bind(erd, $testElem[0])).not.toThrow();
 
-            var listener = jasmine.createSpy("listener");
+            const listener = jasmine.createSpy("listener");
             erd.listenTo($testElem[0], listener);
             expect(erd.uninstall.bind(erd, $testElem[0])).not.toThrow();
             expect(erd.uninstall.bind(erd, $testElem[0])).not.toThrow();
@@ -1072,14 +1072,14 @@ function removalTest(strategy) {
 function importantRuleTest(strategy) {
     describe("[" + strategy + "] resizeDetector.important", function () {
         it("should add all rules with important", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 callOnAdd: true,
                 strategy: strategy,
                 important: true
             });
 
-            var testElem = $("#test");
-            var listenerCall = jasmine.createSpy("listener");
+            const testElem = $("#test");
+            const listenerCall = jasmine.createSpy("listener");
 
             erd.listenTo(testElem[0], listenerCall);
 
@@ -1089,7 +1089,7 @@ function importantRuleTest(strategy) {
                 }
 
                 testElem.find("*").toArray().forEach(function (element) {
-                    var rules = element.style.cssText.split(";").filter(function (rule) {
+                    const rules = element.style.cssText.split(";").filter(function (rule) {
                         return !!rule;
                     });
 
@@ -1103,15 +1103,15 @@ function importantRuleTest(strategy) {
         });
 
         it("Overrides important CSS", function (done) {
-            var erd = elementResizeDetectorMaker({
+            const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
                 strategy: strategy,
                 important: true
             });
 
-            var listener = jasmine.createSpy("listener");
-            var testElem = $("#test");
-            var style = document.createElement("style");
+            const listener = jasmine.createSpy("listener");
+            const testElem = $("#test");
+            const style = document.createElement("style");
             style.appendChild(document.createTextNode("#test { position: static !important; }"));
             document.head.appendChild(style);
 
@@ -1143,7 +1143,7 @@ describe("element-resize-detector", function () {
         });
 
         it("should create an element-resize-detector instance", function () {
-            var erd = elementResizeDetectorMaker();
+            const erd = elementResizeDetectorMaker();
 
             expect(erd).toBeDefined();
             expect(erd.listenTo).toBeDefined();

--- a/test/element-resize-detector_test.js
+++ b/test/element-resize-detector_test.js
@@ -55,13 +55,13 @@ function getAttributes(element) {
 const ensureAttributes = ensureMapEqual;
 
 const reporter = {
-    log: function () {
+    log() {
         throw new Error("Reporter.log should not be called");
     },
-    warn: function () {
+    warn() {
         throw new Error("Reporter.warn should not be called");
     },
-    error: function () {
+    error() {
         throw new Error("Reporter.error should not be called");
     }
 };
@@ -73,8 +73,8 @@ function listenToTest(strategy) {
         it("should be able to attach a listener to an element", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
-                reporter: reporter,
-                strategy: strategy
+                reporter,
+                strategy
             });
 
             const listener = jasmine.createSpy("listener");
@@ -94,8 +94,8 @@ function listenToTest(strategy) {
         it("should throw on invalid parameters", function () {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
-                reporter: reporter,
-                strategy: strategy
+                reporter,
+                strategy
             });
 
             expect(erd.listenTo).toThrow();
@@ -107,14 +107,14 @@ function listenToTest(strategy) {
             it("should be called when installing a listener to an element", function (done) {
                 const erd = elementResizeDetectorMaker({
                     callOnAdd: false,
-                    reporter: reporter,
-                    strategy: strategy
+                    reporter,
+                    strategy
                 });
 
                 const listener = jasmine.createSpy("listener");
 
                 erd.listenTo({
-                    onReady: function () {
+                    onReady() {
                         $("#test").width(200);
                         setTimeout(function () {
                             expect(listener).toHaveBeenCalledWith($("#test")[0]);
@@ -127,14 +127,14 @@ function listenToTest(strategy) {
             it("should be called when all elements are ready", function (done) {
                 const erd = elementResizeDetectorMaker({
                     callOnAdd: false,
-                    reporter: reporter,
-                    strategy: strategy
+                    reporter,
+                    strategy
                 });
 
                 const listener = jasmine.createSpy("listener");
 
                 erd.listenTo({
-                    onReady: function () {
+                    onReady() {
                         $("#test").width(200);
                         $("#test2").width(300);
                         setTimeout(function () {
@@ -149,8 +149,8 @@ function listenToTest(strategy) {
             it("should be able to handle listeners for the same element but different calls", function (done) {
                 const erd = elementResizeDetectorMaker({
                     callOnAdd: false,
-                    reporter: reporter,
-                    strategy: strategy
+                    reporter,
+                    strategy
                 });
 
                 const onReady1 = jasmine.createSpy("listener");
@@ -175,8 +175,8 @@ function listenToTest(strategy) {
             it("should be able to handle when elements occur multiple times in the same call (and other calls)", function (done) {
                 const erd = elementResizeDetectorMaker({
                     callOnAdd: false,
-                    reporter: reporter,
-                    strategy: strategy
+                    reporter,
+                    strategy
                 });
 
                 const onReady1 = jasmine.createSpy("listener");
@@ -202,8 +202,8 @@ function listenToTest(strategy) {
         it("should be able to attach multiple listeners to an element", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
-                reporter: reporter,
-                strategy: strategy
+                reporter,
+                strategy
             });
 
             const listener1 = jasmine.createSpy("listener1");
@@ -226,8 +226,8 @@ function listenToTest(strategy) {
         it("should be able to attach a listener to an element multiple times within the same call", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
-                reporter: reporter,
-                strategy: strategy
+                reporter,
+                strategy
             });
 
             const listener1 = jasmine.createSpy("listener1");
@@ -248,8 +248,8 @@ function listenToTest(strategy) {
         it("should be able to attach listeners to multiple elements", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
-                reporter: reporter,
-                strategy: strategy
+                reporter,
+                strategy
             });
 
             const listener1 = jasmine.createSpy("listener1");
@@ -280,8 +280,8 @@ function listenToTest(strategy) {
             it("should keep the style of the element intact", function (done) {
                 const erd = elementResizeDetectorMaker({
                     callOnAdd: false,
-                    reporter: reporter,
-                    strategy: strategy
+                    reporter,
+                    strategy
                 });
 
                 function ignoreStyleChange(key, before, after) {
@@ -307,8 +307,8 @@ function listenToTest(strategy) {
         describe("options.callOnAdd", function () {
             it("should be true default and call all functions when listenTo succeeds", function (done) {
                 const erd = elementResizeDetectorMaker({
-                    reporter: reporter,
-                    strategy: strategy
+                    reporter,
+                    strategy
                 });
 
                 const listener = jasmine.createSpy("listener");
@@ -334,8 +334,8 @@ function listenToTest(strategy) {
 
             it("should call listener multiple times when listening to multiple elements", function (done) {
                 const erd = elementResizeDetectorMaker({
-                    reporter: reporter,
-                    strategy: strategy
+                    reporter,
+                    strategy
                 });
 
                 const listener1 = jasmine.createSpy("listener1");
@@ -352,8 +352,8 @@ function listenToTest(strategy) {
         it("should call listener if the element is changed synchronously after listenTo", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
-                reporter: reporter,
-                strategy: strategy
+                reporter,
+                strategy
             });
 
             const listener1 = jasmine.createSpy("listener1");
@@ -369,8 +369,8 @@ function listenToTest(strategy) {
         it("should not emit resize when listenTo is called", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
-                reporter: reporter,
-                strategy: strategy
+                reporter,
+                strategy
             });
 
             const listener1 = jasmine.createSpy("listener1");
@@ -385,8 +385,8 @@ function listenToTest(strategy) {
         it("should not emit resize event even though the element is back to its start size", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
-                reporter: reporter,
-                strategy: strategy
+                reporter,
+                strategy
             });
 
             const listener = jasmine.createSpy("listener1");
@@ -415,7 +415,7 @@ function listenToTest(strategy) {
             const ID_ATTR = "some-fancy-id-attr";
 
             const idHandler = {
-                get: function (element, readonly) {
+                get(element, readonly) {
                     if (element[ID_ATTR] === undefined) {
                         if (readonly) {
                             return null;
@@ -426,7 +426,7 @@ function listenToTest(strategy) {
 
                     return $(element).attr(ID_ATTR);
                 },
-                set: function (element) {
+                set(element) {
                     let id;
 
                     if ($(element).attr("id") === "test") {
@@ -442,10 +442,10 @@ function listenToTest(strategy) {
             };
 
             const erd = elementResizeDetectorMaker({
-                idHandler: idHandler,
+                idHandler,
                 callOnAdd: false,
-                reporter: reporter,
-                strategy: strategy
+                reporter,
+                strategy
             });
 
             const listener1 = jasmine.createSpy("listener1");
@@ -486,8 +486,8 @@ function listenToTest(strategy) {
         it("should be able to install into elements that are detached from the DOM", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
-                reporter: reporter,
-                strategy: strategy
+                reporter,
+                strategy
             });
 
             const listener1 = jasmine.createSpy("listener1");
@@ -513,8 +513,8 @@ function listenToTest(strategy) {
         it("should handle iframes, by using initDocument", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
-                strategy: strategy,
-                reporter: reporter
+                strategy,
+                reporter
             });
 
             const listener1 = jasmine.createSpy("listener1");
@@ -547,8 +547,8 @@ function listenToTest(strategy) {
         it("should detect resizes caused by padding and font-size changes", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
-                reporter: reporter,
-                strategy: strategy
+                reporter,
+                strategy
             });
 
             const listener = jasmine.createSpy("listener");
@@ -576,8 +576,8 @@ function listenToTest(strategy) {
             it("when installing", function (done) {
                 const erd = elementResizeDetectorMaker({
                     callOnAdd: false,
-                    reporter: reporter,
-                    strategy: strategy
+                    reporter,
+                    strategy
                 });
 
                 $("#test").html("<div id=\"inner\"></div>");
@@ -607,8 +607,8 @@ function listenToTest(strategy) {
             it("when element gets unrendered after installation", function (done) {
                 const erd = elementResizeDetectorMaker({
                     callOnAdd: false,
-                    reporter: reporter,
-                    strategy: strategy
+                    reporter,
+                    strategy
                 });
 
                 // The div is rendered to begin with.
@@ -642,8 +642,8 @@ function listenToTest(strategy) {
             it("should be listenable", function (done) {
                 const erd = elementResizeDetectorMaker({
                     callOnAdd: false,
-                    reporter: reporter,
-                    strategy: strategy
+                    reporter,
+                    strategy
                 });
 
                 $("#test").html("<span id=\"inner\">test</span>");
@@ -665,8 +665,8 @@ function listenToTest(strategy) {
             it("should not get altered dimensions", function (done) {
                 const erd = elementResizeDetectorMaker({
                     callOnAdd: false,
-                    reporter: reporter,
-                    strategy: strategy
+                    reporter,
+                    strategy
                 });
 
                 $("#test").html("<span id=\"inner\"></span>");
@@ -688,8 +688,8 @@ function listenToTest(strategy) {
         it("should handle dir=rtl correctly", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
-                reporter: reporter,
-                strategy: strategy
+                reporter,
+                strategy
             });
 
             const listener = jasmine.createSpy("listener");
@@ -710,8 +710,8 @@ function listenToTest(strategy) {
         it("should handle fast consecutive resizes", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
-                strategy: strategy,
-                reporter: reporter
+                strategy,
+                reporter
             });
 
             const listener = jasmine.createSpy("listener");
@@ -761,7 +761,7 @@ function removalTest(strategy) {
         it("should remove listener from element", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
-                strategy: strategy
+                strategy
             });
 
             const $testElem = $("#test");
@@ -789,7 +789,7 @@ function removalTest(strategy) {
         it("should remove all listeners from element", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
-                strategy: strategy
+                strategy
             });
 
             const $testElem = $("#test");
@@ -814,7 +814,7 @@ function removalTest(strategy) {
 
         it("should work for elements that don't have the detector installed", function () {
             const erd = elementResizeDetectorMaker({
-                strategy: strategy
+                strategy
             });
             const $testElem = $("#test");
             expect(erd.removeAllListeners.bind(erd, $testElem[0])).not.toThrow();
@@ -858,7 +858,7 @@ function removalTest(strategy) {
         it("should be able to call uninstall and then install in the middle of a resize (issue #61)", function (done) {
             const erd = elementResizeDetectorMaker({
                 strategy: "scroll",
-                reporter: reporter
+                reporter
             });
 
             const $testElem = $("#test");
@@ -898,7 +898,7 @@ function removalTest(strategy) {
             it("should work for elements within an open shadow root (issue #127)", function(done) {
                 const erd = elementResizeDetectorMaker({
                     callOnAdd: false,
-                    reporter: reporter,
+                    reporter,
                     strategy: "scroll"
                 });
 
@@ -927,7 +927,7 @@ function removalTest(strategy) {
         it("should completely remove detector from element", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
-                strategy: strategy
+                strategy
             });
 
             const $testElem = $("#test");
@@ -952,7 +952,7 @@ function removalTest(strategy) {
         it("should completely remove detector from multiple elements", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
-                strategy: strategy
+                strategy
             });
 
             const listener = jasmine.createSpy("listener");
@@ -975,7 +975,7 @@ function removalTest(strategy) {
 
         it("should be able to call uninstall directly after listenTo", function () {
             const erd = elementResizeDetectorMaker({
-                strategy: strategy
+                strategy
             });
 
             const $testElem = $("#test");
@@ -987,7 +987,7 @@ function removalTest(strategy) {
 
         it("should be able to call uninstall directly async after listenTo", function (done) {
             const erd = elementResizeDetectorMaker({
-                strategy: strategy
+                strategy
             });
 
             const $testElem = $("#test");
@@ -1009,7 +1009,7 @@ function removalTest(strategy) {
             };
 
             const erd = elementResizeDetectorMaker({
-                strategy: strategy,
+                strategy,
                 callOnAdd: true
             });
 
@@ -1033,7 +1033,7 @@ function removalTest(strategy) {
             };
 
             const erd = elementResizeDetectorMaker({
-                strategy: strategy,
+                strategy,
                 callOnAdd: true
             });
 
@@ -1054,7 +1054,7 @@ function removalTest(strategy) {
 
         it("should be able to call uninstall on non-erd elements", function () {
             const erd = elementResizeDetectorMaker({
-                strategy: strategy
+                strategy
             });
 
             const $testElem = $("#test");
@@ -1074,7 +1074,7 @@ function importantRuleTest(strategy) {
         it("should add all rules with important", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: true,
-                strategy: strategy,
+                strategy,
                 important: true
             });
 
@@ -1105,7 +1105,7 @@ function importantRuleTest(strategy) {
         it("Overrides important CSS", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
-                strategy: strategy,
+                strategy,
                 important: true
             });
 

--- a/test/element-resize-detector_test.js
+++ b/test/element-resize-detector_test.js
@@ -69,7 +69,7 @@ const reporter = {
 $("body").prepend("<div id=fixtures></div>");
 
 function listenToTest(strategy) {
-    describe("[" + strategy + "] listenTo", function () {
+    describe(`[${strategy}] listenTo`, function () {
         it("should be able to attach a listener to an element", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
@@ -757,7 +757,7 @@ function listenToTest(strategy) {
 }
 
 function removalTest(strategy) {
-    describe("[" + strategy + "] resizeDetector.removeListener", function () {
+    describe(`[${strategy}] resizeDetector.removeListener`, function () {
         it("should remove listener from element", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
@@ -785,7 +785,7 @@ function removalTest(strategy) {
         });
     });
 
-    describe("[" + strategy + "] resizeDetector.removeAllListeners", function () {
+    describe(`[${strategy}] resizeDetector.removeAllListeners`, function () {
         it("should remove all listeners from element", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
@@ -923,7 +923,7 @@ function removalTest(strategy) {
         }
     });
 
-    describe("[" + strategy + "] resizeDetector.uninstall", function () {
+    describe(`[${strategy}] resizeDetector.uninstall`, function () {
         it("should completely remove detector from element", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: false,
@@ -1070,7 +1070,7 @@ function removalTest(strategy) {
 }
 
 function importantRuleTest(strategy) {
-    describe("[" + strategy + "] resizeDetector.important", function () {
+    describe(`[${strategy}] resizeDetector.important`, function () {
         it("should add all rules with important", function (done) {
             const erd = elementResizeDetectorMaker({
                 callOnAdd: true,


### PR DESCRIPTION
This PR:
- converts the usage of var/let to let/const.
- uses object shorthand to simplify the code
- uses string template literals to simplify the code

### Method

JSCodeshift developed by Facebook parses the AST and performs scope analysis, reference counting, etc to verify that these changes are safe.

The example of `var` conversion for src folder:
```
git clone https://github.com/cpojer/js-codemod.git
cd element-resize-detector
jscodeshift -t ../js-codemod/transforms/no-vars.js ./src
```

### Benefits

- Using `var` results in unwanted behavior because its scope is leaked upwards. This PR prevents these kinds of bugs. JsCodeshift already finds the cases where the conversion is not safe and `var` is leaked intentionally and leaves them as is.
- `var` conversion allows the JavaScript engine to perform better optimizations for the code
- using object shorthand and string template literal simplifies the code

### How to review

The commits are separate with the command run for each in the description. The changes are automated using jscodeshift which is more accurate than human eyes as it does AST analysis. 

Only the [last commit](https://github.com/wnr/element-resize-detector/pull/130/commits/0f7e0858348e0e0187bb71cb404f7ef40d95c76c) was manual.